### PR TITLE
initialize webpack setup and create readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # reactjsdenver.com
+
+Clone the repo:
+
+```
+$ git clone git@github.com:reactjsdenver/reactjsdenver.com.git
+```
+If you do not have babel, webpack, and webpack-dev-server installed globally
+run:
+
+```
+$ npm install babel webpack webpack-dev-server -g
+```
+
+Install the dependencies:
+
+```
+$ npm install
+```
+
+Invoke webpack:
+
+```
+$ npm build
+```
+
+Start the dev server:
+
+```
+$ npm start
+```

--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@ Clone the repo:
 ```
 $ git clone git@github.com:reactjsdenver/reactjsdenver.com.git
 ```
-If you do not have babel, webpack, and webpack-dev-server installed globally
-run:
-
-```
-$ npm install babel webpack webpack-dev-server -g
-```
 
 Install the dependencies:
 

--- a/app/App.js
+++ b/app/App.js
@@ -1,0 +1,4 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+ReactDOM.render(<Main />, document.getElementById('app'))

--- a/app/components/Main.js
+++ b/app/components/Main.js
@@ -1,0 +1,1 @@
+import React from 'react'

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "reactjsdenver.com",
+  "version": "1.0.0",
+  "description": "Website for reactjsdenver meetup",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server",
+    "build": "webpack"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reactjsdenver/reactjsdenver.com.git"
+  },
+  "author": "Will Klein, Regina Peyfuss, David Parker, Nate Venn",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/reactjsdenver/reactjsdenver.com/issues"
+  },
+  "homepage": "https://github.com/reactjsdenver/reactjsdenver.com#readme",
+  "dependencies": {
+    "react": "^15.3.0",
+    "react-dom": "^15.3.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "reactjsdenver.com",
+  "private": "true",
   "version": "1.0.0",
   "description": "Website for reactjsdenver meetup",
   "main": "index.js",
@@ -12,13 +13,19 @@
     "url": "git+https://github.com/reactjsdenver/reactjsdenver.com.git"
   },
   "author": "Will Klein, Regina Peyfuss, David Parker, Nate Venn",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/reactjsdenver/reactjsdenver.com/issues"
   },
   "homepage": "https://github.com/reactjsdenver/reactjsdenver.com#readme",
   "dependencies": {
     "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "react-dom": "^15.3.0",
+    "babel": "^6.3.13",
+    "babel-core": "^6.3.15",
+    "babel-loader": "^6.2.0",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "webpack-dev-server": "^1.14.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ReactJS-Denver</title>
+</head>
+<body>
+<div id="app"></div>
+<script src="/bundle.js"></script>
+</body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,22 @@
+module.export = {
+  entry: './app/App.js',
+  output: {
+    filename: 'public/bundle.js'
+  },
+  devServer: {
+    inline: true,
+    port: 8080
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['es2015', 'react']
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
@willklein @davidwparker @rpeyfuss 
This is structured similarly to the last React app I worked on. Let the discussions begin if there are other preferences. I'm open to learning other ways. 
1. run npm init
2. install react react-dom babel-loader babel-core babel-preset-es2015 and
   babel-preset-react
3. create app/component/Main.js
4. create app/App.js
5. create public/index.html
6. create webpack.config.js and configure webpack
7. add script start to run server
8. add script build to build webpack
9. update readme
